### PR TITLE
Change default library path to /calibre-main/ with deprecation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ pyproject.toml
 # Test Scripts
 */test
 test*
-*dirs.json
 */DEV
 */REFERENCE
 cwa.db

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ services:
     volumes:
       - /path/to/config/folder:/config
       - /path/to/the/folder/you/want/to/use/for/book/ingest:/cwa-book-ingest
-      - "/path/to/your/calibre/library:/calibre-main/Calibre Library"
+      - /path/to/your/calibre/library:/calibre-main/
       #- /path/to/where/you/keep/your/books:/books #Optional
       #- /path/to/your/gmail/credentials.json:/app/calibre-web/gmail.json #Optional
     ports:
@@ -101,8 +101,8 @@ services:
 - **Explanation of the Container Bindings:**
   - **/config** - Can be any empty folder, used to store logs and other miscellaneous files that keep CWA running
   - **/cwa-book-ingest** - **ATTENTION** ⚠️ - All files within this folder will be **DELETED** after being processed. This folder should only be used to dump new books into for import and automatic conversion
-  - **/calibre-main/Calibre Library** - This should be bound to your Calibre library folder where the `metadata.db` file resides within.   
-      - If you don't have an **existing** Calibre Database, create a folder for your library, place the `metadata.db` file from the project's GitHub page within it, and bind it to `/calibre-main/Calibre Library` shown above. Follow the steps below after building the container
+  - **/calibre-main/** - This should be bound to your Calibre library folder where the `metadata.db` file resides within.   
+      - If you don't have an **existing** Calibre Database, create a folder for your library, place the `metadata.db` file from the project's GitHub page within it, and bind it to `/calibre-main/` shown above. Follow the steps below after building the container
   - **/books** _(Optional)_ - This is purely optional, I personally bind /books to where I store my downloaded books so that they accessible from within the container but CWA doesn't require this
   - **/gmail.json** _(Optional)_ - This is used to setup Calibre-Web and/or CWA with your gmail account for sending books via email. Follow the guide [here](https://github.com/janeczku/calibre-web/wiki/Setup-Mailserver#gmail) if this is something you're interested in but be warned it can be a very fiddly process, I would personally recommend a simple SMTP Server
 ### 2. And just like that, Calibre-Web Automated should be up and running!

--- a/calibre-web-automator/dirs.json
+++ b/calibre-web-automator/dirs.json
@@ -1,0 +1,5 @@
+{
+    "ingest_folder": "/cwa-book-ingest",
+    "import_folder": "/etc/calibre-web-automator/cwa-import",
+    "calibre_library_dir": "/calibre-main/"
+  }

--- a/calibre-web-automator/manage_deprecations.sh
+++ b/calibre-web-automator/manage_deprecations.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# This is for installations before the default library change from "/calibre-main/Calibre Library
+# to /calibre-main. This ensures no hiccups for these older installations
+if [ -d "/calibre-main/Calibre Library" ];then
+	echo "Calibre Library detected. Changing cwa library path to it..."
+	tmp=$(mktemp)
+	dirpath="/etc/calibre-web-automator/dirs.json"
+
+	# Modify calibre_library_dir to "/calibre-main/Calibre Library"
+	jq '.calibre_library_dir = "/calibre-main/Calibre Library"' $dirpath > "$tmp" && mv "$tmp" $dirpath
+fi
+


### PR DESCRIPTION
This adds two things:

1. A script for managing this and future deprecations
2. adding dirs.json to the repository
3. changing the default "calibre_library_dir" in dir.json to "/calibre-main/"

This will reduce directory complexity and improve the installation experience, especially for users with container managers such as Synology where spaces aren't allowed during volume binds in `docker-compose.yml`.